### PR TITLE
avoid importing files twice, fixes "Duplicate name in namespace" bug

### DIFF
--- a/parser/protobuf.js
+++ b/parser/protobuf.js
@@ -5,10 +5,8 @@
  */
 var fs = require('fs');
 var path = require('path');
-var nodePath = path;
 var ProtoBuf = require('protobufjs');
 var util = require('protobufjs/cli/pbjs/util');
-
 var optionsHandler = require('../options');
 var parseProtobufString;
 var parseProtobuf;
@@ -16,6 +14,11 @@ var parseProtobuf;
 parseProtobuf = function (protoBufPath, options, loaded) {
     options = optionsHandler.verify(options);
     protoBufPath = path.resolve(protoBufPath);
+    if (loaded.indexOf(protoBufPath) >= 0)
+        return {};
+    else {
+        loaded.push(protoBufPath)
+    }
     var data = fs.readFileSync(protoBufPath, options.encoding || 'utf-8');
     return parseProtobufString(data, options, loaded);
 };
@@ -24,30 +27,25 @@ parseProtobufString = function (protoBufString, options, loaded) {
     options = optionsHandler.verify(options);
     var parser = new ProtoBuf.DotProto.Parser(protoBufString);
     var data = parser.parse();
-    loaded = loaded || {};
-    if (Array.isArray(data.imports)) {
-        var imports = data.imports;
-        for (var i = 0; i < imports.length; i++) {
+    loaded = loaded || [];
+    if (Array.isArray(data['imports'])) {
+        var imports = data['imports'];
+        for (var i=0; i<imports.length; i++) {
             // Skip pulled imports and legacy descriptors
-            if (typeof imports[i] !== 'string' || (util.isDescriptor(imports[i]) && !options.legacy)) {
+            if (typeof imports[i] !== 'string' || (util.isDescriptor(imports[i]) && !options.legacy))
                 continue;
-            }
             // Merge imports, try include paths
-            var fileFound = false;
-            var path = options.path || [];
-            for (var j = 0; j < path.length; ++j) {
-                var importFilename = nodePath.resolve(path[j] + '/', imports[i]);
-                if (!fs.existsSync(importFilename)) {
-                    continue;
+            (function() {
+                var path = options.path || [];
+                for (var j=0; j<path.length; ++j) {
+                    var import_filename = path.resolve(path[j] + "/", imports[i]);
+                    if (!fs.existsSync(import_filename))
+                        continue;
+                    imports[i] = parseProtobuf(import_filename, options, loaded);
+                    return;
                 }
-                imports[i] = parseProtobuf(importFilename, options, loaded);
-                fileFound = true;
-                break;
-            }
-            if (!fileFound) {
-                throw Error('File not found: ' + imports[i]);
-            }
-
+                throw Error("File not found: "+imports[i]);
+            })();
         }
     }
     return data;

--- a/test/files/cyclic-dependency-check/organization.proto
+++ b/test/files/cyclic-dependency-check/organization.proto
@@ -1,0 +1,8 @@
+import 'person.proto';
+import 'telephone.proto';
+package test;
+
+message Organization {
+    repeated Person employees = 1;
+    repeated PhoneNumber phone = 2;
+}

--- a/test/files/cyclic-dependency-check/person.proto
+++ b/test/files/cyclic-dependency-check/person.proto
@@ -1,0 +1,14 @@
+package test;
+import 'telephone.proto';
+
+message Person {
+  required string name = 1;
+  required int32 id = 2;
+  optional string email = 3;
+
+  repeated PhoneNumber phone = 4;
+}
+
+message AddressBook {
+  repeated Person person = 1;
+}

--- a/test/files/cyclic-dependency-check/telephone.proto
+++ b/test/files/cyclic-dependency-check/telephone.proto
@@ -1,0 +1,13 @@
+package test;
+
+message PhoneNumber {
+
+    enum PhoneType {
+        MOBILE = 0;
+        HOME = 1;
+        WORK = 2;
+    }
+
+    required string number = 1;
+    optional PhoneType type = 2 [default = HOME];
+}

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -202,7 +202,7 @@ describe('index', function () {
                     contents: new Buffer(protoBufData),
                     path: protoBufPath,
                     base: basePath,
-                    cwd : "/"
+                    cwd : '/'
                 });
                 var plugin = gulpprotobuf({
                     path: basePath


### PR DESCRIPTION
This fixes a bug where the same file got imported multiple times. 

For example if there is a file A,B and C. B imports A and C imports B and A. This caused a "Duplicate name in namespace ..." exception. 
